### PR TITLE
Patch deprecated fractions.gcd

### DIFF
--- a/recipe/fix-deprecated-gcd.patch
+++ b/recipe/fix-deprecated-gcd.patch
@@ -1,0 +1,11 @@
+--- xcbgen/align.py.orig	2021-01-08 15:27:12.000000000 -0800
++++ xcbgen/align.py	2021-01-08 15:27:19.000000000 -0800
+@@ -2,7 +2,7 @@
+ This module contains helper classes for alignment arithmetic and checks
+ '''
+ 
+-from fractions import gcd
++from math import gcd
+ 
+ class Alignment(object):
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - windows-pythondir.patch  # [win]
+    - fix-deprecated-gcd.patch
 
 build:
-  number: 1005
+  number: 1006
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The `fractions.gcd` has been deprecated since python 3.5 and removed in 3.9.  This patches that to the replacement `math.gcd`.